### PR TITLE
Clarifications for POD/DMD routines

### DIFF
--- a/Modal_Decomposition.ipynb
+++ b/Modal_Decomposition.ipynb
@@ -724,10 +724,11 @@
     "       Each matrix can be multidimensional, but time must be the last axis.\n",
     "    weight: List of weight matrices for weighting the snapshots. Each element conatins\n",
     "       to the weight matrix for the corresponding element of X.\n",
-    "    \n",
     "    Returns\n",
     "    -------\n",
-    "    pod_modes: Matrix of pod_modes (mode_index, variable, space).\n",
+    "    pod_modes: List of arrays of pod modes. Each element of the list gives the pod modes \n",
+    "       for the corresponding physical variable given in X. Each pod mode array has layout \n",
+    "       (mode_index, variable, space).\n",
     "    eigval: eigenvalues corresponding to the pod_modes.\n",
     "    pod_mode_amplitudes: Temporal amplitudes corresponding to the pod_modes\n",
     "    \"\"\"\n",
@@ -782,7 +783,7 @@
     "POD_data_u = (u_LC - u_bar).transpose(1, 2, 0)\n",
     "POD_data_v = (v_LC - v_bar).transpose(1, 2, 0)\n",
     "# Get a rank 20 POD decomposition\n",
-    "eigval, pod_modes, pod_mode_amplitudes = POD([POD_data_u, POD_data_v], rank=20)"
+    "eigval, pod_modes, pod_mode_amplitudes = POD([POD_data_u, POD_data_v], weights=[mass_u, mass_v], rank=20)"
    ]
   },
   {
@@ -808,8 +809,9 @@
    "outputs": [],
    "source": [
     "# Plot the first POD-mode\n",
-    "plot_cylinder_data(xu, yu, pod_modes[0][0].real, fig_ax=None, cmap='bwr')\n",
-    "plot_cylinder_data(xv, yv, pod_modes[1][0].real, fig_ax=None, cmap='bwr')"
+    "mode_index = 0\n",
+    "plot_cylinder_data(xu, yu, pod_modes[0][mode_index].real, fig_ax=None, cmap='bwr') # 0 is the u-component\n",
+    "plot_cylinder_data(xv, yv, pod_modes[1][mode_index].real, fig_ax=None, cmap='bwr') # 1 is the v-component"
    ]
   },
   {
@@ -868,7 +870,7 @@
     "mode_2_fft = np.fft.fftshift(np.abs(np.fft.fft(second_mode_amplitude)))\n",
     "plt.semilogy(freqs, mode_0_fft, label=r'POD mode 0')\n",
     "plt.semilogy(freqs, mode_2_fft, label=r'POD mode 2')\n",
-    "plt.ylim([1e1, 1e5])\n",
+    "plt.ylim([1e-1, 1e4])\n",
     "plt.xlim([0, 1])\n",
     "plt.xlabel('Frequency (Hz)')\n",
     "plt.ylabel('FFT amplitude')\n",
@@ -918,7 +920,7 @@
     "$$\n",
     "\\tilde{\\mathbf{B}}_r= \\mathbf{U}_r^T\\mathbf{B}_r\\mathbf{U}_r = \\mathbf{U}_r^T\\mathbf{Y}\\mathbf{V}_r\\Sigma_r^{-1}.\n",
     "$$\n",
-    "As $\\mathbf{U}_r$ is unitary, the first equivalencey in the above expression shows that our $r\\times r$ matrix $\\tilde{\\mathbf{B}}_r$ shares the same eigenvalues as the larger matrix $\\mathbf{B}_r$. Hence, DMD proceeds by finding the eigenvalues $\\mu_i$ and eigenvectors $\\tilde{v}_i$ of $\\tilde{\\mathbf{B}}_r$. From this, the eigenvectors of $\\mathbf{B}_r$ can be found via $v_i=\\mu_i^{-1}\\mathbf{X}\\mathbf{V}_r\\Sigma_r^{-1}\\tilde{v}_i$.  This completes the DMD algorithm.\n"
+    "As $\\mathbf{U}_r$ is unitary, the first equivalencey in the above expression shows that our $r\\times r$ matrix $\\tilde{\\mathbf{B}}_r$ shares the same eigenvalues as the larger matrix $\\mathbf{B}_r$. Hence, DMD proceeds by finding the eigenvalues $\\mu_i$ and eigenvectors $\\tilde{v}_i$ of $\\tilde{\\mathbf{B}}_r$. From this, the eigenvectors of $\\mathbf{B}_r$ can be found via $v_i=\\mu_i^{-1}\\mathbf{X}\\mathbf{V}_r\\Sigma_r^{-1}\\tilde{v}_i$.  This completes the DMD algorithm."
    ]
   },
   {
@@ -942,7 +944,9 @@
     "    Returns\n",
     "    -------\n",
     "    eigval: eigenvalues corresponding to the DMD_modes.\n",
-    "    DMD_modes: Matrix of DMD_modes (mode-index, variable, space).\n",
+    "    DMD_modes: List of arrays of dmd modes. Each element of the list gives the dmd modes \n",
+    "       for the corresponding physical variable given in X. Each dmd mode array has layout \n",
+    "       (mode_index, variable, space).\n",
     "    dmd_mode_amplitudes: Array of amplitudes of the dmd modes.\n",
     "    \"\"\"\n",
     "    orig_shapes = []\n",
@@ -989,7 +993,20 @@
    "id": "f555e9c0",
    "metadata": {},
    "source": [
-    "With the DMD modes now computed, lets compare them to the POD modes. Plotting the eigenvalues of each mode immediately shows a difference. Whereas the POD mode eigenvalues represent how much total energy of the flow they capture, the DMD mode eigenvalues represents the time-dependence of the mode. As we have performed DMD on the limit cycle data, all the modes are neutral (i.e. they lie on the unit circle). This means the modes do not grow or decay. However, they oscillate at the frequency given by the imaginary part of the eigenvalue. Note, that as for a linear equation $\\dot{\\mathbf{x}}=\\mathbf{L}\\mathbf{x}$ the DMD modes are the eigenvalues of $\\exp(\\mathbf{L}\\Delta t)$, it is common to instead convert the eigenvalues $\\mu_i$ to $\\lambda_i=\\log(\\mu_i)\\Delta t$. We display both below."
+    "With the DMD modes now computed, let's compare them to the POD modes. Plotting the eigenvalues of each mode immediately shows a difference. Whereas the POD mode eigenvalues represent how much total energy of the flow they capture, the DMD mode eigenvalues represent the time-dependence of the mode. As we have performed DMD on the limit cycle data, all the modes are neutral (i.e. they lie on the unit circle). This means the modes do not grow or decay. However, they oscillate at the frequency given by the imaginary part of the eigenvalue. Note, that as for a linear equation $\\dot{\\mathbf{x}}=\\mathbf{L}\\mathbf{x}$ the DMD modes are the eigenvalues of $\\exp(\\mathbf{L}\\Delta t)$, it is common to instead convert the eigenvalues $\\mu_i$ to $\\lambda_i=\\log(\\mu_i)/\\Delta t$. In this manner, we have two ways to examine the time-dependence of mode $\\mathbf{v}_i$. Firstly, if we have an initial condition written as the sum of DMD modes\n",
+    "$$\n",
+    "\\mathbf{q}(t_0) = \\sum_i a_i \\mathbf{v}_i,\n",
+    "$$\n",
+    "then the flow after $n$ timesteps $\\Delta t$ can be calculated from the DMD eigenvalues via\n",
+    "$$\n",
+    "\\mathbf{q}(t_0 + n \\Delta t) = \\sum_i a_i\\mu_i^n\\mathbf{v}_i.\n",
+    "$$\n",
+    "Secondly, if we use $\\lambda$ we can write a continuous representation of our flow as follows\n",
+    "$$\n",
+    "\\mathbf{q}(t_0 + t) = \\sum_i a_i\\exp(\\lambda_i t)\\mathbf{v}_i.\n",
+    "$$\n",
+    "From both equations we see that each DMD mode has a growth/decay rate and oscillates at a single frequency.\n",
+    "We display both below."
    ]
   },
   {
@@ -1031,8 +1048,9 @@
    "outputs": [],
    "source": [
     "# Plot the first DMD-mode\n",
-    "plot_cylinder_data(xu, yu, dmd_modes[0][0].imag, fig_ax=None, cmap='bwr')\n",
-    "plot_cylinder_data(xv, yv, dmd_modes[1][0].real, fig_ax=None, cmap='bwr')"
+    "mode_index = 0\n",
+    "plot_cylinder_data(xu, yu, dmd_modes[0][mode_index].real, fig_ax=None, cmap='bwr') # 0 is the u-component\n",
+    "plot_cylinder_data(xv, yv, dmd_modes[1][mode_index].real, fig_ax=None, cmap='bwr') # 1 is the v-component"
    ]
   },
   {
@@ -1155,7 +1173,7 @@
    "lastKernelId": null
   },
   "kernelspec": {
-   "display_name": "MD",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -19,7 +19,9 @@ def DMD(X, rank=10):
     Returns
     -------
     eigval: eigenvalues corresponding to the DMD_modes.
-    DMD_modes: Matrix of DMD_modes (mode-index, variable, space).
+    DMD_modes: List of arrays of dmd modes. Each element of the list gives the dmd modes 
+       for the corresponding physical variable given in X. Each dmd mode array has layout 
+       (mode_index, variable, space).
     dmd_mode_amplitudes: Array of amplitudes of the dmd modes.
     """
     orig_shapes = []
@@ -60,10 +62,11 @@ def POD(X, weights=None, rank=10):
        Each matrix can be multidimensional, but time must be the last axis.
     weight: List of weight matrices for weighting the snapshots. Each element conatins
        to the weight matrix for the corresponding element of X.
-    
     Returns
     -------
-    pod_modes: Matrix of pod_modes (mode_index, variable, space).
+    pod_modes: List of arrays of pod modes. Each element of the list gives the pod modes 
+       for the corresponding physical variable given in X. Each pod mode array has layout 
+       (mode_index, variable, space).
     eigval: eigenvalues corresponding to the pod_modes.
     pod_mode_amplitudes: Temporal amplitudes corresponding to the pod_modes
     """


### PR DESCRIPTION
This pull request adds a few clarifications to the modal decomposition notebook. 

- More description is provided on what the DMD eigenvalues represent. 
- Weight matrices are now used for the POD analysis of cylinder flow.
- A few clarifications are made in the documentation for the POD/DMD routines for how the output is returned.